### PR TITLE
Fix type declaration error or antd.Slider.value

### DIFF
--- a/.changeset/few-jeans-design.md
+++ b/.changeset/few-jeans-design.md
@@ -1,0 +1,5 @@
+---
+'modelscope_studio': patch
+---
+
+fix: Fix type declaration error or antd.Slider.value

--- a/backend/modelscope_studio/components/antd/slider/__init__.py
+++ b/backend/modelscope_studio/components/antd/slider/__init__.py
@@ -29,13 +29,14 @@ class AntdSlider(ModelScopeDataLayoutComponent):
 
     def __init__(
             self,
-            value: int | float | list[int | float] | None = None,
+            value: int | float | tuple[int | float, int | float]
+        | list[int | float] | None = None,
             props: dict | None = None,
             *,
             auto_focus: bool | None = None,
             class_names: dict | None = None,
             default_value: int | float | tuple[int | float, int | float]
-        | None = None,
+        | list[int | float] | None = None,
             disabled: bool | None = None,
             dots: bool | None = None,
             included: bool | None = True,

--- a/backend/modelscope_studio/components/antd/slider/__init__.py
+++ b/backend/modelscope_studio/components/antd/slider/__init__.py
@@ -29,7 +29,7 @@ class AntdSlider(ModelScopeDataLayoutComponent):
 
     def __init__(
             self,
-            value: int | float | tuple[int | float, int | float] | None = None,
+            value: int | float | list[int | float] | None = None,
             props: dict | None = None,
             *,
             auto_focus: bool | None = None,


### PR DESCRIPTION
Close: https://github.com/modelscope/modelscope-studio/issues/49

修改value的声明为`value: int | float | list[int | float] | None = None,`后问题解决。
![image](https://github.com/user-attachments/assets/c31d924a-aaa1-4433-8bba-86cda65a3057)
