### PR TITLE
fix: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ templates
 !.gitattributes
 !.aoneci.yml
 !.editorconfig
+package-lock.json
 
 # Logs
 logs


### PR DESCRIPTION
增加忽略 package-lock.json
项目会生成 package-lock.json 临时文件, git status时会显示